### PR TITLE
Skip remaining characters after IndexError

### DIFF
--- a/src/PIL/PcfFontFile.py
+++ b/src/PIL/PcfFontFile.py
@@ -241,8 +241,10 @@ class PcfFontFile(FontFile.FontFile):
                 ]
                 if encoding_offset != 0xFFFF:
                     encoding[i] = encoding_offset
-            except (UnicodeDecodeError, IndexError):
+            except UnicodeDecodeError:
                 # character is not supported in selected encoding
                 pass
+            except IndexError:
+                break
 
         return encoding


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/6386

From what I can see, after the IndexError is hit, all of the remaining characters won't work either. So my suggestion is to break out of the loop, rather than keep trying and fail.